### PR TITLE
Makefile: update poetry install sync to no longer use deprecated invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ $(POETRY): $(SYS_PYTHON) poetry.toml
 	@touch $@
 
 $(POETRY_DEPS): $(POETRY) pyproject.toml poetry.lock
-	$(POETRY) install --sync --no-root
+	$(POETRY) sync --no-root
 	@touch $@
 
 PY_SOURCE_ROOTS:=bin/lib bin/test lambda


### PR DESCRIPTION
Poetry deprecated `install --sync` in favor of `sync`. Move to the newer invocation.